### PR TITLE
管理画面の順番を維持するnodeを追加

### DIFF
--- a/src/sourceNodes.js
+++ b/src/sourceNodes.js
@@ -43,10 +43,11 @@ message: ${body.message}`);
           reporter.panic(`format set to 'list' but got ${typeof body.contents}`);
           return;
         }
-        body.contents.forEach(content => {
+        body.contents.forEach((content, index) => {
           createContentNode({
             createNode,
             createNodeId,
+            sortIndex: index,
             content: content,
             type: type,
           });

--- a/src/utils.js
+++ b/src/utils.js
@@ -18,7 +18,13 @@ const isObjectContent = ({ format, content }) => {
   );
 };
 
-const createContentNode = ({ createNode, createNodeId, content, type }) => {
+const createContentNode = ({
+  createNode,
+  createNodeId,
+  sortIndex,
+  content,
+  type,
+}) => {
   const nodeContent = JSON.stringify(content);
   const nodeId = createNodeId(content.id || nodeContent);
   const nodeContentDigest = crypto
@@ -29,6 +35,7 @@ const createContentNode = ({ createNode, createNodeId, content, type }) => {
   const node = {
     ...content,
     id: nodeId,
+    sortIndex: sortIndex,
     parent: null,
     children: [],
     internal: {


### PR DESCRIPTION
#11 の修正案です！

sortIndexという順序パラメータを付与してみました。GraphQLで以下のように使えます。

```graphql
query MyQuery {
  allMicrocmsPost(sort: {fields: sortIndex, order: ASC}) {
    edges {
      node {
        sortIndex
        title
      }
    }
  }
}
```