### PR TITLE
管理画面の順番を維持するnodeにoffsetを反映

### DIFF
--- a/src/sourceNodes.js
+++ b/src/sourceNodes.js
@@ -44,10 +44,11 @@ message: ${body.message}`);
           return;
         }
         body.contents.forEach((content, index) => {
+          let sortIndex = offset + index;
           createContentNode({
             createNode,
             createNodeId,
-            sortIndex: index,
+            sortIndex: sortIndex,
             content: content,
             type: type,
           });

--- a/src/sourceNodes.js
+++ b/src/sourceNodes.js
@@ -44,11 +44,10 @@ message: ${body.message}`);
           return;
         }
         body.contents.forEach((content, index) => {
-          let sortIndex = offset + index;
           createContentNode({
             createNode,
             createNodeId,
-            sortIndex: sortIndex,
+            sortIndex: offset + index,
             content: content,
             type: type,
           });


### PR DESCRIPTION
#11 の修正案に追加です！

sortIndexを取り入れていただき、ありがとうございます。

10件以下のデータでは問題ありませんでしたが、11件以上はwhileでindexがリセットされるようです。そこでoffsetにindexを足していくよう修正してみました。

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/9658016/127281686-71b93cbe-909b-4102-9308-907deaa665a3.png) | ![image](https://user-images.githubusercontent.com/9658016/127281743-e051d88d-9193-4c69-b585-cc164ca71930.png) |
| 11, 21, 31...件目が0 | 最後まで連番 |