### PR TITLE
fix: サービスやAPIを跨いで同一のコンテンツIDのものが重複してしまう現象を修正

### DIFF
--- a/src/sourceNodes.js
+++ b/src/sourceNodes.js
@@ -15,9 +15,6 @@ const sourceNodes = async (
       'serviceId'
     )}.microcms.io/api/${pluginConfig.get('version')}/${api.endpoint}`;
 
-    // type option. default is endpoint value.
-    const type = api.type || api.endpoint;
-
     const { format = 'list' } = api;
 
     // get all list data
@@ -47,8 +44,10 @@ message: ${body.message}`);
             createNode,
             createNodeId,
             sortIndex: offset + index,
-            content: content,
-            type: type,
+            content,
+            serviceId: pluginConfig.get('serviceId'),
+            endpoint: api.endpoint,
+            type: api.type,
           });
         });
 
@@ -82,7 +81,9 @@ message: ${body.message}`);
         createNode,
         createNodeId,
         content: body,
-        type: type,
+        serviceId: pluginConfig.get('serviceId'),
+        endpoint: api.endpoint,
+        type: api.type,
       });
     }
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -18,19 +18,35 @@ const isObjectContent = ({ format, content }) => {
   );
 };
 
+const makeId = ({ serviceId, id, endpoint, type }) => {
+  return `${serviceId}___${id}___${endpoint}${type ? `___${type}` : ''}`;
+};
+
 const createContentNode = ({
   createNode,
   createNodeId,
   sortIndex,
   content,
+  serviceId,
+  endpoint,
   type,
 }) => {
   const nodeContent = JSON.stringify(content);
-  const nodeId = createNodeId(content.id || nodeContent);
+  const nodeId = createNodeId(
+    makeId({
+      serviceId,
+      id: content.id || nodeContent,
+      endpoint,
+      type,
+    })
+  );
   const nodeContentDigest = crypto
     .createHash('md5')
     .update(nodeContent)
     .digest('hex');
+
+  // type option. default is endpoint value.
+  const _type = type || endpoint;
 
   const node = {
     ...content,
@@ -39,7 +55,7 @@ const createContentNode = ({
     parent: null,
     children: [],
     internal: {
-      type: makeTypeName(type),
+      type: makeTypeName(_type),
       content: nodeContent,
       contentDigest: nodeContentDigest,
     },
@@ -50,7 +66,7 @@ const createContentNode = ({
    * rename to ${type}Id if content has id property.
    */
   if (content.id) {
-    const contentIdName = camelCase([type, 'id']);
+    const contentIdName = camelCase([_type, 'id']);
     node[contentIdName] = content.id;
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -18,8 +18,8 @@ const isObjectContent = ({ format, content }) => {
   );
 };
 
-const makeId = ({ serviceId, id, endpoint, type }) => {
-  return `${serviceId}___${id}___${endpoint}${type ? `___${type}` : ''}`;
+const makeId = ({ serviceId, id, endpoint }) => {
+  return `${serviceId}___${id}___${endpoint}`;
 };
 
 const createContentNode = ({
@@ -37,7 +37,6 @@ const createContentNode = ({
       serviceId,
       id: content.id || nodeContent,
       endpoint,
-      type,
     })
   );
   const nodeContentDigest = crypto


### PR DESCRIPTION
## 概要

サービスやAPIを跨いで同一のコンテンツIDが存在する場合に
どちらかのコンテンツが上書きされてしまい、（Gatsbyの仕組み的にidの重複によって）
正常に動きません。
これを修正するため、サービスID、APIのエンドポイントをID生成に含めることで解決します。

⚠️ これは破壊的変更を含みます。
ユーザーが取得できるidの値が変更されるため、たとえばURLにそれを用いていた場合はそれも自動的に変更されます。
Gatsbyの仕組み的にGraphQLから取得できるidはコンテンツIDではなくなるため、
URLなどに使用するものを`${type}Id`に変更してもらう案内も一緒にすべきかと思います。